### PR TITLE
支持 Spotify 逐字模式

### DIFF
--- a/README-English.md
+++ b/README-English.md
@@ -26,7 +26,7 @@
 | 🧊 **LX Music**                      | `lx-music`          | Supports translated lyrics display                 |
 | 🐶 **Kugou Music / Concept Edition** | `kugou-music`       | **Requires enabling car lyrics mode in the app**   |
 | 📻 **Kuwo Music**                    | `kuwo-music`        | **Requires enabling car lyrics mode in the app**   |
-| 🎧 **Spotify**                       | `spotify-music`     | Currently only supports standard lyrics            |
+| 🎧 **Spotify**                       | `spotify-music`     | Supports standard lyrics and per-word lyrics       |
 | ⚡ **Poweramp**                       | `poweramp-music`    | Supports online matching and embedded local lyrics |
 | 🧂 **Salt Music**                    | `salt-player-music` | Adapted based on Meizu standard lyric interface    |
 | 🎵 **Qishui Music**                  | `qishui-music`      | Supports dynamic lyrics, translated lyrics         |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | 🧊 **LX 音乐**       | `lx-music`          | 支持翻译歌词显示             |
 | 🐶 **酷狗音乐/概念版**    | `kugou-music`       | **需在 App 内开启车载歌词模式** |
 | 📻 **酷我音乐**        | `kuwo-music`        | **需在 App 内开启车载歌词模式** |
-| 🎧 **Spotify**     | `spotify-music`     | 目前仅支持标准歌词            |
+| 🎧 **Spotify**     | `spotify-music`     | 支持标准歌词、逐字歌词          |
 | ⚡ **Poweramp**     | `poweramp-music`    | 支持网络匹配及本地内嵌歌词        |
 | 🧂 **Salt 音乐**     | `salt-player-music` | 基于魅族标准歌词接口适配         |
 | 🎵 **汽水音乐**        | `qishui-music`      | 支持动态歌词、翻译歌词          |

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/Converter.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/Converter.kt
@@ -6,11 +6,43 @@
 
 package io.github.proify.lyricon.spotifyprovider.xposed
 
+import io.github.proify.lyricon.lyric.model.LyricWord
 import io.github.proify.lyricon.lyric.model.RichLyricLine
 import io.github.proify.lyricon.lyric.model.Song
+import io.github.proify.lyricon.spotifyprovider.xposed.api.SpotifyApi.jsonParser
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricLine
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricResponse
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricsData
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoSyllable
 import io.github.proify.lyricon.spotifyprovider.xposed.api.response.LyricResponse
 import io.github.proify.lyricon.spotifyprovider.xposed.api.response.LyricsData
+import io.github.proify.lyricon.spotifyprovider.xposed.parser.SpotifyProtoParser
 
+/**
+ * 将 Spotify 原始响应字节转换为歌曲。
+ *
+ * 响应可能是 protobuf（逐字数据所在）或 JSON（服务端降级），按首字节自动分流：
+ * - 首字节 `{`：走原 JSON 序列化路径（行级歌词）；
+ * - 其余：走 protobuf 解析路径（行级 + 逐字歌词）。
+ *
+ * @return 转换后的歌曲；响应为空或解析失败返回 null
+ */
+fun ByteArray.toSongOrNull(id: String): Song? {
+    if (isEmpty()) return null
+    return if (isJsonBody()) {
+        runCatching { jsonParser.decodeFromString<LyricResponse>(toString(Charsets.UTF_8)) }
+            .getOrNull()
+            ?.toSong(id)
+    } else {
+        SpotifyProtoParser.parse(this)?.toSong(id)
+    }
+}
+
+private fun ByteArray.isJsonBody(): Boolean = first() == '{'.code.toByte()
+
+/**
+ * JSON 响应转歌曲（原有行级实现）。
+ */
 fun LyricResponse.toSong(id: String): Song {
     val metadata = MetadataCache.get(id)
     val song = Song()
@@ -46,3 +78,76 @@ fun LyricsData.toLyrics(): List<RichLyricLine> {
 
     return lyrics
 }
+
+/**
+ * protobuf 响应转歌曲。
+ */
+fun ProtoLyricResponse.toSong(id: String): Song {
+    val metadata = MetadataCache.get(id)
+    return Song(
+        id = id,
+        name = metadata?.title,
+        artist = metadata?.artist,
+        duration = (metadata?.duration ?: 0L).let { if (it <= 0L) Long.MAX_VALUE else it },
+        lyrics = lyrics?.toLyrics()
+    )
+}
+
+/**
+ * protobuf 歌词主体转富歌词行列表。
+ */
+fun ProtoLyricsData.toLyrics(): List<RichLyricLine> = lines.toRichLyricLines()
+
+/**
+ * protobuf 歌词行转富歌词行。
+ *
+ * 行级 [endTimeMs] 在 protobuf 中通常缺省，按下一行起始时间兜底，最后一行 +5000ms；
+ * 逐字数据有效的行携带 [LyricWord] 列表，否则回退为纯行级歌词。
+ */
+fun List<ProtoLyricLine>.toRichLyricLines(): List<RichLyricLine> =
+    mapIndexedNotNull { index, line ->
+        val text = line.words ?: return@mapIndexedNotNull null
+        if (text.isBlank()) return@mapIndexedNotNull null
+        val endTimeMs = getOrNull(index + 1)?.startTimeMs ?: (line.startTimeMs + 5000L)
+        RichLyricLine(
+            begin = line.startTimeMs,
+            end = endTimeMs,
+            duration = endTimeMs - line.startTimeMs,
+            text = text,
+            words = line.toLyricWords()
+        )
+    }
+
+/**
+ * 按 [ProtoSyllable.count] 累计游标切片整行文本，生成逐字 [LyricWord]。
+ *
+ * 任一音节计数异常或累计长度与整行文本不一致时返回 null，
+ * 由调用方回退为纯行级歌词，避免切片错位。
+ */
+private fun ProtoLyricLine.toLyricWords(): List<LyricWord>? {
+    val text = words ?: return null
+    if (syllables.isEmpty()) return null
+
+    val sliced = syllables.fold(SliceState()) { state, syllable ->
+        if (syllable.count < 0 || state.offset + syllable.count > text.length) return null
+        val endOffset = state.offset + syllable.count
+        state.copy(
+            offset = endOffset,
+            words = state.words + LyricWord(
+                begin = syllable.startTimeMs,
+                end = syllable.endTimeMs,
+                duration = (syllable.endTimeMs - syllable.startTimeMs).coerceAtLeast(0L),
+                text = text.substring(state.offset, endOffset)
+            )
+        )
+    }
+    return sliced.words.takeIf { sliced.offset == text.length }
+}
+
+/**
+ * 切片过程中的不可变游标状态。
+ */
+private data class SliceState(
+    val offset: Int = 0,
+    val words: List<LyricWord> = emptyList()
+)

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/DiskCache.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/DiskCache.kt
@@ -12,15 +12,15 @@ import java.util.Locale
 
 object DiskCache {
 
-    fun put(context: Context, id: String, content: String) {
+    fun put(context: Context, id: String, content: ByteArray) {
         val file = getFile(context, id)
         file.parentFile?.mkdirs()
-        file.writeText(content)
+        file.writeBytes(content)
     }
 
-    fun get(context: Context, id: String): String? {
+    fun get(context: Context, id: String): ByteArray? {
         val file = getFile(context, id)
-        return if (file.exists()) file.readText() else null
+        return if (file.exists()) file.readBytes() else null
     }
 
     private fun getFile(context: Context, id: String): File =

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/DownloadCallback.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/DownloadCallback.kt
@@ -7,6 +7,6 @@
 package io.github.proify.lyricon.spotifyprovider.xposed
 
 interface DownloadCallback {
-    fun onDownloadFinished(id: String, response: String)
+    fun onDownloadFinished(id: String, response: ByteArray)
     fun onDownloadFailed(id: String, e: Exception)
 }

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/Spotify.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/Spotify.kt
@@ -18,8 +18,6 @@ import io.github.proify.lyricon.provider.LyriconProvider
 import io.github.proify.lyricon.provider.ProviderLogo
 import io.github.proify.lyricon.spotifyprovider.xposed.api.NoFoundLyricException
 import io.github.proify.lyricon.spotifyprovider.xposed.api.SpotifyApi
-import io.github.proify.lyricon.spotifyprovider.xposed.api.SpotifyApi.jsonParser
-import io.github.proify.lyricon.spotifyprovider.xposed.api.response.LyricResponse
 import java.util.Locale
 
 object Spotify : YukiBaseHooker(), DownloadCallback {
@@ -125,18 +123,14 @@ object Spotify : YukiBaseHooker(), DownloadCallback {
         Downloader.download(id, this)
     }
 
-    override fun onDownloadFinished(id: String, response: String) {
+    override fun onDownloadFinished(id: String, response: ByteArray) {
         applyResponse(id, response)
         appContext?.let { DiskCache.put(it, id, response) }
     }
 
-    private fun applyResponse(id: String, response: String) {
-        val lyricResponse =
-            runCatching { jsonParser.decodeFromString<LyricResponse>(response) }.getOrNull()
-        if (lyricResponse != null) {
-            val song = lyricResponse.toSong(id)
-            if (song != lastSong) setSong(song)
-        }
+    private fun applyResponse(id: String, response: ByteArray) {
+        val song = response.toSongOrNull(id) ?: return
+        if (song != lastSong) setSong(song)
     }
 
     override fun onDownloadFailed(id: String, e: Exception) {

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/api/SpotifyApi.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/api/SpotifyApi.kt
@@ -6,11 +6,9 @@
 
 package io.github.proify.lyricon.spotifyprovider.xposed.api
 
-import android.util.Log
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.json.JSONObject
 import java.io.IOException
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -27,7 +25,6 @@ object SpotifyApi {
         "x-client-id"
     )
 
-    private const val TAG = "SpotifyApi"
     private const val BASE_URL = "https://guc3-spclient.spotify.com/color-lyrics/v2/track/"
 
     val headers = mutableMapOf<String, String>()
@@ -48,29 +45,30 @@ object SpotifyApi {
     }
 
     /**
-     * 根据歌曲 ID 获取原始歌词字符串
+     * 根据歌曲 ID 获取原始歌词字节
      *
      * @param id 歌曲唯一标识
-     * @return 歌词 JSON 字符串
+     * @return 歌词原始字节（protobuf；服务端降级时可能是 JSON）
      * @throws Exception 网络错误或解析异常
      */
     @Throws(Exception::class)
-    fun fetchRawLyric(id: String): String = performNetworkRequest(id)
+    fun fetchRawLyric(id: String): ByteArray = performNetworkRequest(id)
 
     /**
      * 执行实际的网络请求逻辑
      */
     @Throws(Exception::class)
-    private fun performNetworkRequest(id: String): String {
-        val url = "$BASE_URL$id?vocalRemoval=false&clientLanguage=${
+    private fun performNetworkRequest(id: String): ByteArray {
+        val url = "$BASE_URL$id?vocalRemoval=true&clientLanguage=${
             Locale.getDefault().toLanguageTag()
         }&preview=false"
 
         val requestBuilder = Request.Builder()
             .url(url)
             .get()
-            .addHeader("accept", "application/json")
-            .addHeader("app-platform", "WebPlayer")
+            .addHeader("accept", "application/protobuf")
+            .addHeader("content-type", "application/protobuf")
+            .addHeader("app-platform", "Android")
 
         // 注入外部配置的 Header
         headers.forEach { (key, value) ->
@@ -81,7 +79,7 @@ object SpotifyApi {
 
         client.newCall(request).execute().use { response ->
             val code = response.code
-            val bodyString = response.body.string()
+            val body = response.body.bytes()
 
             if (code == 404) {
                 throw NoFoundLyricException(id, "No lyric found for $id")
@@ -91,13 +89,7 @@ object SpotifyApi {
                 throw IOException("HTTP error code: $code, msg: ${response.message}")
             }
 
-            return try {
-                JSONObject(bodyString)
-                bodyString
-            } catch (e: Exception) {
-                Log.e(TAG, "Invalid JSON response for $id: $bodyString", e)
-                throw IOException("Invalid JSON response")
-            }
+            return body
         }
     }
 }

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/api/proto/ProtoModels.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/api/proto/ProtoModels.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Proify, Tomakino
+ * Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.proify.lyricon.spotifyprovider.xposed.api.proto
+
+/**
+ * Spotify color-lyrics protobuf 响应模型。
+ *
+ * 字段编号与抓包逆向得到的 wire schema 一一对应，
+ * 仅保留歌词展示所需的字段，未知字段在解析时直接跳过。
+ */
+data class ProtoLyricResponse(
+    val lyrics: ProtoLyricsData? = null,
+    val colors: ProtoColorData? = null
+)
+
+/**
+ * 歌词主体。
+ *
+ * @property syncType 同步类型，1 = 行同步，2 = 逐字同步（仅作参考，不参与判断）
+ * @property lines 正文字幕行，逐字数据挂在该字段
+ * @property previewLines 预览行，结构与 [lines] 相同，可忽略
+ */
+data class ProtoLyricsData(
+    val syncType: Int = 0,
+    val lines: List<ProtoLyricLine> = emptyList(),
+    val provider: String? = null,
+    val providerLyricsId: String? = null,
+    val providerDisplayName: String? = null,
+    val previewLines: List<ProtoLyricLine> = emptyList()
+)
+
+/**
+ * 单行歌词。
+ *
+ * @property startTimeMs 行起始毫秒
+ * @property words 整行文本
+ * @property syllables 逐字（音节级）块；无逐字的行该列表为空
+ */
+data class ProtoLyricLine(
+    val startTimeMs: Long = 0,
+    val words: String? = null,
+    val syllables: List<ProtoSyllable> = emptyList()
+)
+
+/**
+ * 逐字（音节）块。
+ *
+ * @property startTimeMs 块起始毫秒
+ * @property count 块覆盖的字符数（UTF-16 code unit，与 String.length 一致）
+ * @property endTimeMs 块结束毫秒
+ */
+data class ProtoSyllable(
+    val startTimeMs: Long = 0,
+    val count: Int = 0,
+    val endTimeMs: Long = 0
+)
+
+/**
+ * 响应中的颜色信息（负 int32 按补码解释）。
+ */
+data class ProtoColorData(
+    val background: Int = 0,
+    val text: Int = 0,
+    val highlightText: Int = 0
+)

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/parser/SpotifyProtoParser.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/parser/SpotifyProtoParser.kt
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026 Proify, Tomakino
+ * Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.proify.lyricon.spotifyprovider.xposed.parser
+
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoColorData
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricLine
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricResponse
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricsData
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoSyllable
+
+/**
+ * Spotify color-lyrics protobuf 响应解析器。
+ *
+ * 纯函数实现：输入原始字节，输出不可变模型；字节损坏或遇到不支持的 wire type 时返回 null。
+ * 解析过程不依赖任何 Android / Xposed 上下文，可独立单元测试。
+ */
+object SpotifyProtoParser {
+
+    private const val FIELD_LYRICS = 1
+    private const val FIELD_COLORS = 2
+
+    private const val FIELD_SYNC_TYPE = 1
+    private const val FIELD_LINES = 2
+    private const val FIELD_PROVIDER = 3
+    private const val FIELD_PROVIDER_LYRICS_ID = 4
+    private const val FIELD_PROVIDER_DISPLAY_NAME = 5
+    private const val FIELD_PREVIEW_LINES = 17
+
+    private const val FIELD_START_TIME_MS = 1
+    private const val FIELD_WORDS = 2
+    private const val FIELD_SYLLABLES = 3
+
+    private const val FIELD_COUNT = 2
+    private const val FIELD_END_TIME_MS = 3
+
+    private const val WIRE_VARINT = 0
+    private const val WIRE_FIXED64 = 1
+    private const val WIRE_LENGTH_DELIMITED = 2
+    private const val WIRE_FIXED32 = 5
+
+    /**
+     * 解析完整响应。
+     *
+     * @param bytes 服务端返回的原始 protobuf 字节
+     * @return 解析后的不可变响应模型；解析失败返回 null
+     */
+    fun parse(bytes: ByteArray): ProtoLyricResponse? = runCatching {
+        parseLyricResponse(ProtoCursor(bytes)).value
+    }.getOrNull()
+
+    // ---------------------------------- 不可变游标与解析结果 ----------------------------------
+
+    private data class ProtoCursor(val bytes: ByteArray, val offset: Int = 0) {
+        val isEnd: Boolean get() = offset >= bytes.size
+        fun remaining(): Int = bytes.size - offset
+    }
+
+    private data class Parsed<out T>(val value: T, val cursor: ProtoCursor)
+
+    private data class FieldTag(val number: Int, val wireType: Int)
+
+    // ---------------------------------- 基础 wire 读取 ----------------------------------
+
+    private fun ProtoCursor.readVarint(): Parsed<Long> {
+        var value = 0L
+        var shift = 0
+        var cursor = this
+        while (true) {
+            if (cursor.isEnd) throw IllegalArgumentException("Unexpected end of protobuf while reading varint")
+            val byte = cursor.bytes[cursor.offset].toInt() and 0xFF
+            cursor = cursor.copy(offset = cursor.offset + 1)
+            value = value or ((byte and 0x7F).toLong() shl shift)
+            if (byte and 0x80 == 0) return Parsed(value, cursor)
+            shift += 7
+            if (shift >= 64) throw IllegalArgumentException("Malformed protobuf varint")
+        }
+    }
+
+    private fun ProtoCursor.readTag(): Parsed<FieldTag> {
+        val (raw, next) = readVarint()
+        val tag = raw.toInt()
+        return Parsed(FieldTag(tag ushr 3, tag and 0x07), next)
+    }
+
+    private fun ProtoCursor.readLengthDelimited(): Parsed<ByteArray> {
+        val (length, afterLength) = readVarint()
+        val lengthInt = length.toInt()
+        if (length > Int.MAX_VALUE.toLong() || lengthInt > afterLength.remaining()) {
+            throw IllegalArgumentException("Truncated protobuf length-delimited field")
+        }
+        val end = afterLength.offset + lengthInt
+        return Parsed(afterLength.bytes.copyOfRange(afterLength.offset, end), afterLength.copy(offset = end))
+    }
+
+    private fun ProtoCursor.skip(wireType: Int): ProtoCursor = when (wireType) {
+        WIRE_VARINT -> readVarint().cursor
+        WIRE_FIXED64 -> copy(offset = offset + 8)
+        WIRE_LENGTH_DELIMITED -> readLengthDelimited().cursor
+        WIRE_FIXED32 -> copy(offset = offset + 4)
+        else -> throw IllegalArgumentException("Unsupported protobuf wire type: $wireType")
+    }
+
+    private fun Parsed<ByteArray>.toUtf8String(): Parsed<String> =
+        Parsed(String(value, Charsets.UTF_8), cursor)
+
+    // ---------------------------------- 消息解析 ----------------------------------
+
+    private fun parseLyricResponse(start: ProtoCursor): Parsed<ProtoLyricResponse> {
+        var lyrics: ProtoLyricsData? = null
+        var colors: ProtoColorData? = null
+        var cursor = start
+        while (!cursor.isEnd) {
+            val (field, next) = cursor.readTag()
+            when (field.number) {
+                FIELD_LYRICS -> {
+                    val payload = next.readLengthDelimited()
+                    lyrics = parseLyricsData(payload.value).value
+                    cursor = payload.cursor
+                }
+
+                FIELD_COLORS -> {
+                    val payload = next.readLengthDelimited()
+                    colors = parseColorData(payload.value)
+                    cursor = payload.cursor
+                }
+
+                else -> cursor = next.skip(field.wireType)
+            }
+        }
+        return Parsed(ProtoLyricResponse(lyrics = lyrics, colors = colors), cursor)
+    }
+
+    private fun parseLyricsData(start: ProtoCursor): Parsed<ProtoLyricsData> {
+        var syncType = 0
+        var provider: String? = null
+        var providerLyricsId: String? = null
+        var providerDisplayName: String? = null
+        val lines = mutableListOf<ProtoLyricLine>()
+        val previewLines = mutableListOf<ProtoLyricLine>()
+        var cursor = start
+        while (!cursor.isEnd) {
+            val (field, next) = cursor.readTag()
+            when (field.number) {
+                FIELD_SYNC_TYPE -> {
+                    val parsed = next.readVarint()
+                    syncType = parsed.value.toInt()
+                    cursor = parsed.cursor
+                }
+
+                FIELD_LINES -> {
+                    val payload = next.readLengthDelimited()
+                    lines += parseLyricLine(payload.value).value
+                    cursor = payload.cursor
+                }
+
+                FIELD_PROVIDER -> {
+                    val payload = next.readLengthDelimited().toUtf8String()
+                    provider = payload.value
+                    cursor = payload.cursor
+                }
+
+                FIELD_PROVIDER_LYRICS_ID -> {
+                    val payload = next.readLengthDelimited().toUtf8String()
+                    providerLyricsId = payload.value
+                    cursor = payload.cursor
+                }
+
+                FIELD_PROVIDER_DISPLAY_NAME -> {
+                    val payload = next.readLengthDelimited().toUtf8String()
+                    providerDisplayName = payload.value
+                    cursor = payload.cursor
+                }
+
+                FIELD_PREVIEW_LINES -> {
+                    val payload = next.readLengthDelimited()
+                    previewLines += parseLyricLine(payload.value).value
+                    cursor = payload.cursor
+                }
+
+                else -> cursor = next.skip(field.wireType)
+            }
+        }
+        return Parsed(
+            ProtoLyricsData(
+                syncType = syncType,
+                lines = lines,
+                provider = provider,
+                providerLyricsId = providerLyricsId,
+                providerDisplayName = providerDisplayName,
+                previewLines = previewLines
+            ),
+            cursor
+        )
+    }
+
+    private fun parseLyricLine(start: ProtoCursor): Parsed<ProtoLyricLine> {
+        var startTimeMs = 0L
+        var words: String? = null
+        val syllables = mutableListOf<ProtoSyllable>()
+        var cursor = start
+        while (!cursor.isEnd) {
+            val (field, next) = cursor.readTag()
+            when (field.number) {
+                FIELD_START_TIME_MS -> {
+                    val parsed = next.readVarint()
+                    startTimeMs = parsed.value
+                    cursor = parsed.cursor
+                }
+
+                FIELD_WORDS -> {
+                    val payload = next.readLengthDelimited().toUtf8String()
+                    words = payload.value
+                    cursor = payload.cursor
+                }
+
+                FIELD_SYLLABLES -> {
+                    val payload = next.readLengthDelimited()
+                    syllables += parseSyllable(payload.value).value
+                    cursor = payload.cursor
+                }
+
+                else -> cursor = next.skip(field.wireType)
+            }
+        }
+        return Parsed(ProtoLyricLine(startTimeMs = startTimeMs, words = words, syllables = syllables), cursor)
+    }
+
+    private fun parseSyllable(start: ProtoCursor): Parsed<ProtoSyllable> {
+        var startTimeMs = 0L
+        var count = 0
+        var endTimeMs = 0L
+        var cursor = start
+        while (!cursor.isEnd) {
+            val (field, next) = cursor.readTag()
+            when (field.number) {
+                FIELD_START_TIME_MS -> {
+                    val parsed = next.readVarint()
+                    startTimeMs = parsed.value
+                    cursor = parsed.cursor
+                }
+
+                FIELD_COUNT -> {
+                    val parsed = next.readVarint()
+                    count = parsed.value.toInt()
+                    cursor = parsed.cursor
+                }
+
+                FIELD_END_TIME_MS -> {
+                    val parsed = next.readVarint()
+                    endTimeMs = parsed.value
+                    cursor = parsed.cursor
+                }
+
+                else -> cursor = next.skip(field.wireType)
+            }
+        }
+        return Parsed(ProtoSyllable(startTimeMs, count, endTimeMs), cursor)
+    }
+
+    private fun parseColorData(start: ProtoCursor): ProtoColorData {
+        val values = buildList {
+            var cursor = start
+            while (!cursor.isEnd) {
+                val (field, next) = cursor.readTag()
+                if (field.wireType == WIRE_VARINT) {
+                    val parsed = next.readVarint()
+                    add(parsed.value.toInt())
+                    cursor = parsed.cursor
+                } else {
+                    cursor = next.skip(field.wireType)
+                }
+            }
+        }
+        return ProtoColorData(
+            background = values.getOrElse(0) { 0 },
+            text = values.getOrElse(1) { 0 },
+            highlightText = values.getOrElse(2) { 0 }
+        )
+    }
+}

--- a/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/parser/SpotifyProtoParser.kt
+++ b/spotify-music/src/main/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/parser/SpotifyProtoParser.kt
@@ -118,13 +118,13 @@ object SpotifyProtoParser {
             when (field.number) {
                 FIELD_LYRICS -> {
                     val payload = next.readLengthDelimited()
-                    lyrics = parseLyricsData(payload.value).value
+                    lyrics = parseLyricsData(ProtoCursor(payload.value)).value
                     cursor = payload.cursor
                 }
 
                 FIELD_COLORS -> {
                     val payload = next.readLengthDelimited()
-                    colors = parseColorData(payload.value)
+                    colors = parseColorData(ProtoCursor(payload.value))
                     cursor = payload.cursor
                 }
 
@@ -153,7 +153,7 @@ object SpotifyProtoParser {
 
                 FIELD_LINES -> {
                     val payload = next.readLengthDelimited()
-                    lines += parseLyricLine(payload.value).value
+                    lines += parseLyricLine(ProtoCursor(payload.value)).value
                     cursor = payload.cursor
                 }
 
@@ -177,7 +177,7 @@ object SpotifyProtoParser {
 
                 FIELD_PREVIEW_LINES -> {
                     val payload = next.readLengthDelimited()
-                    previewLines += parseLyricLine(payload.value).value
+                    previewLines += parseLyricLine(ProtoCursor(payload.value)).value
                     cursor = payload.cursor
                 }
 
@@ -219,7 +219,7 @@ object SpotifyProtoParser {
 
                 FIELD_SYLLABLES -> {
                     val payload = next.readLengthDelimited()
-                    syllables += parseSyllable(payload.value).value
+                    syllables += parseSyllable(ProtoCursor(payload.value)).value
                     cursor = payload.cursor
                 }
 

--- a/spotify-music/src/main/res/values/arrays.xml
+++ b/spotify-music/src/main/res/values/arrays.xml
@@ -10,6 +10,8 @@
         <item>com.spotify.music</item>
     </string-array>
 
-    <string-array name="lyricon_module_tags" />
+    <string-array name="lyricon_module_tags">
+        <item>$syllable</item>
+    </string-array>
 
 </resources>

--- a/spotify-music/src/test/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/SpotifyConverterTest.kt
+++ b/spotify-music/src/test/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/SpotifyConverterTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Proify, Tomakino
+ * Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.proify.lyricon.spotifyprovider.xposed
+
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricLine
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoLyricsData
+import io.github.proify.lyricon.spotifyprovider.xposed.api.proto.ProtoSyllable
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SpotifyConverterTest {
+
+    @Test
+    fun 逐字行按count切片并生成LyricWord() {
+        val lines = listOf(
+            ProtoLyricLine(
+                startTimeMs = 52604,
+                words = "On a dark desert highway,",
+                syllables = listOf(
+                    ProtoSyllable(52604, 3, 52694),
+                    ProtoSyllable(52831, 2, 52876),
+                    ProtoSyllable(53012, 5, 53239),
+                    ProtoSyllable(53330, 7, 53784),
+                    ProtoSyllable(53874, 4, 54056),
+                    ProtoSyllable(54147, 4, 54328)
+                )
+            ),
+            ProtoLyricLine(startTimeMs = 55781, words = "Cool wind in my hair,")
+        )
+
+        val richLines = lines.toRichLyricLines()
+
+        assertEquals(2, richLines.size)
+        val first = richLines[0]
+        assertEquals(52604L, first.begin)
+        assertEquals(55781L, first.end)
+        assertEquals(3177L, first.duration)
+        assertEquals("On a dark desert highway,", first.text)
+        assertEquals(
+            listOf("On ", "a ", "dark ", "desert ", "high", "way,"),
+            first.words!!.map { it.text }
+        )
+        assertEquals(
+            listOf(52604L, 52831L, 53012L, 53330L, 53874L, 54147L),
+            first.words!!.map { it.begin }
+        )
+        assertEquals(
+            listOf(52694L, 52876L, 53239L, 53784L, 54056L, 54328L),
+            first.words!!.map { it.end }
+        )
+
+        // 无逐字的行回退为纯行级歌词，末行 end = start + 5000
+        val second = richLines[1]
+        assertEquals(55781L, second.begin)
+        assertEquals(60781L, second.end)
+        assertNull(second.words)
+    }
+
+    @Test
+    fun 累计长度不一致时整行回退纯文本() {
+        val lines = listOf(
+            ProtoLyricLine(
+                startTimeMs = 0,
+                words = "On a dark desert highway,",
+                syllables = listOf(
+                    ProtoSyllable(0, 3, 100),
+                    ProtoSyllable(100, 999, 200)
+                )
+            )
+        )
+
+        val richLines = lines.toRichLyricLines()
+        assertEquals(1, richLines.size)
+        assertNull(richLines[0].words)
+        assertEquals("On a dark desert highway,", richLines[0].text)
+    }
+
+    @Test
+    fun 空白行被过滤() {
+        val lines = listOf(
+            ProtoLyricLine(startTimeMs = 1000, words = "  "),
+            ProtoLyricLine(startTimeMs = 2000, words = "hello")
+        )
+
+        val richLines = lines.toRichLyricLines()
+        assertEquals(1, richLines.size)
+        assertEquals("hello", richLines[0].text)
+    }
+
+    @Test
+    fun lyricsData转富歌词列表() {
+        val data = ProtoLyricsData(
+            syncType = 2,
+            lines = listOf(
+                ProtoLyricLine(
+                    startTimeMs = 0,
+                    words = "hi",
+                    syllables = listOf(ProtoSyllable(0, 2, 100))
+                )
+            )
+        )
+
+        val richLines = data.toLyrics()
+        assertEquals(1, richLines.size)
+        assertEquals(listOf("hi"), richLines[0].words!!.map { it.text })
+    }
+
+    @Test
+    fun JSON响应走原有解析路径() {
+        val json = """
+            {"lyrics":{"syncType":"LINE_SYNCED","lines":[
+                {"startTimeMs":"0","words":"hello","endTimeMs":"100"}
+            ]}}
+        """.trimIndent()
+
+        val song = json.toByteArray().toSongOrNull("track-1")
+        assertNotNull(song)
+        assertEquals("hello", song!!.lyrics!!.single().text)
+    }
+}

--- a/spotify-music/src/test/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/parser/SpotifyProtoParserTest.kt
+++ b/spotify-music/src/test/kotlin/io/github/proify/lyricon/spotifyprovider/xposed/parser/SpotifyProtoParserTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 Proify, Tomakino
+ * Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.proify.lyricon.spotifyprovider.xposed.parser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpotifyProtoParserTest {
+
+    @Test
+    fun 解析包含逐字的完整响应() {
+        val bytes = response(
+            lyricsData(
+                syncType = 2,
+                lines = listOf(
+                    line(
+                        startTimeMs = 52604,
+                        words = "On a dark desert highway,",
+                        syllables = listOf(
+                            syllable(52604, 3, 52694),
+                            syllable(52831, 2, 52876),
+                            syllable(53012, 5, 53239),
+                            syllable(53330, 7, 53784),
+                            syllable(53874, 4, 54056),
+                            syllable(54147, 4, 54328)
+                        )
+                    ),
+                    line(startTimeMs = 55781, words = "Cool wind in my hair,")
+                )
+            ),
+            colors = colors(background = -1, text = -16777216, highlightText = -65536)
+        )
+
+        val parsed = SpotifyProtoParser.parse(bytes)
+        assertNotNull(parsed)
+        val lyrics = parsed!!.lyrics!!
+        assertEquals(2, lyrics.syncType)
+        assertEquals(2, lyrics.lines.size)
+
+        val first = lyrics.lines[0]
+        assertEquals(52604L, first.startTimeMs)
+        assertEquals("On a dark desert highway,", first.words)
+        assertEquals(6, first.syllables.size)
+        assertEquals(listOf(3, 2, 5, 7, 4, 4), first.syllables.map { it.count })
+        assertEquals(
+            listOf(52604L, 52831L, 53012L, 53330L, 53874L, 54147L),
+            first.syllables.map { it.startTimeMs }
+        )
+        assertEquals(
+            listOf(52694L, 52876L, 53239L, 53784L, 54056L, 54328L),
+            first.syllables.map { it.endTimeMs }
+        )
+
+        // 无逐字的行不携带 syllables
+        val second = lyrics.lines[1]
+        assertEquals(55781L, second.startTimeMs)
+        assertEquals("Cool wind in my hair,", second.words)
+        assertTrue(second.syllables.isEmpty())
+
+        val color = parsed.colors!!
+        assertEquals(-1, color.background)
+        assertEquals(-16777216, color.text)
+        assertEquals(-65536, color.highlightText)
+    }
+
+    @Test
+    fun 未知字段按wireType跳过() {
+        val bytes = response(
+            lyricsData(
+                lines = listOf(
+                    line(
+                        startTimeMs = 1000,
+                        words = "hello",
+                        unknownVarint = 42L,
+                        unknownBytes = byteArrayOf(1, 2, 3)
+                    )
+                )
+            )
+        )
+
+        val parsed = SpotifyProtoParser.parse(bytes)
+        assertNotNull(parsed)
+        val first = parsed!!.lyrics!!.lines.single()
+        assertEquals(1000L, first.startTimeMs)
+        assertEquals("hello", first.words)
+        assertTrue(first.syllables.isEmpty())
+    }
+
+    @Test
+    fun 空字节解析为空响应() {
+        val parsed = SpotifyProtoParser.parse(ByteArray(0))
+        assertNotNull(parsed)
+        assertNull(parsed!!.lyrics)
+    }
+
+    @Test
+    fun 非法字节返回null() {
+        // field 1 wire type 3（group start），解析器不支持
+        assertNull(SpotifyProtoParser.parse(byteArrayOf(0x0B)))
+        // 截断的 varint
+        assertNull(SpotifyProtoParser.parse(byteArrayOf(0x08, 0x80)))
+    }
+
+    // ---------------------------------- protobuf 测试数据构造 ----------------------------------
+
+    private fun encodeVarint(value: Long): ByteArray {
+        if (value == 0L) return byteArrayOf(0)
+        val buffer = ByteArray(10)
+        var index = 0
+        var v = value
+        while (v != 0L) {
+            var byte = (v and 0x7F).toInt()
+            v = v ushr 7
+            if (v != 0L) byte = byte or 0x80
+            buffer[index++] = byte.toByte()
+        }
+        return buffer.copyOf(index)
+    }
+
+    private fun field(number: Int, wireType: Int, payload: ByteArray = ByteArray(0)): ByteArray =
+        encodeVarint(((number shl 3) or wireType).toLong()) + payload
+
+    private fun varintField(number: Int, value: Long): ByteArray =
+        field(number, 0, encodeVarint(value))
+
+    private fun bytesField(number: Int, payload: ByteArray): ByteArray =
+        field(number, 2, encodeVarint(payload.size.toLong()) + payload)
+
+    private fun stringField(number: Int, value: String): ByteArray =
+        bytesField(number, value.toByteArray(Charsets.UTF_8))
+
+    private fun response(lyrics: ByteArray, colors: ByteArray? = null): ByteArray =
+        bytesField(1, lyrics) + (colors?.let { bytesField(2, it) } ?: ByteArray(0))
+
+    private fun lyricsData(syncType: Int = 1, lines: List<ByteArray> = emptyList()): ByteArray =
+        varintField(1, syncType.toLong()) +
+            lines.fold(ByteArray(0)) { acc, line -> acc + bytesField(2, line) }
+
+    private fun line(
+        startTimeMs: Long = 0,
+        words: String? = null,
+        syllables: List<ByteArray> = emptyList(),
+        unknownVarint: Long? = null,
+        unknownBytes: ByteArray? = null
+    ): ByteArray {
+        var result = varintField(1, startTimeMs)
+        words?.let { result += stringField(2, it) }
+        unknownVarint?.let { result += varintField(99, it) }
+        unknownBytes?.let { result += bytesField(98, it) }
+        return result + syllables.fold(ByteArray(0)) { acc, item -> acc + bytesField(3, item) }
+    }
+
+    private fun syllable(startTimeMs: Long, count: Int, endTimeMs: Long): ByteArray =
+        varintField(1, startTimeMs) +
+            varintField(2, count.toLong()) +
+            varintField(3, endTimeMs)
+
+    private fun colors(background: Int, text: Int, highlightText: Int): ByteArray =
+        varintField(1, background.toLong()) +
+            varintField(2, text.toLong()) +
+            varintField(3, highlightText.toLong())
+}


### PR DESCRIPTION
This pr will close issue #109 

通过修改请求头从 json 到 Spotify 客户端所使用的 protobuf 来获取完整的带逐字的响应。

然后通过手搓一个简易 protobuf 解析器来对响应解析转换成正确的逐字格式。