### PR TITLE
docs: 修复 README 中的 Star 增长图表

### DIFF
--- a/README-English.md
+++ b/README-English.md
@@ -80,11 +80,11 @@ the [Development Documentation](https://github.com/tomakino/lyricon/blob/master/
 
 ### ⭐ Star History
 
-<a href="https://star-history.com/#tomakino/LyricProvider&Date">
+<a href="https://star-history.dera.page/#tomakino/LyricProvider&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tomakino/LyricProvider&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tomakino/LyricProvider&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tomakino/LyricProvider&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tomakino/LyricProvider&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tomakino/LyricProvider&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tomakino/LyricProvider&type=Date" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@
 
 ### ⭐ Star 增长
 
-<a href="https://star-history.com/#tomakino/LyricProvider&Date">
+<a href="https://star-history.dera.page/#tomakino/LyricProvider&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tomakino/LyricProvider&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tomakino/LyricProvider&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tomakino/LyricProvider&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tomakino/LyricProvider&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tomakino/LyricProvider&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tomakino/LyricProvider&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
目前 README 与英文版 README 中的 Star 增长图表因数据源不可用已无法正常显示，Star 数据也不再有意义。本 PR 将两处图表（含深色/浅色模式）迁移到可正常更新的服务地址，链接参数保持不变。修复后图表即可重新展示仓库的 Star 增长趋势。